### PR TITLE
Add base public path to 8x2 app

### DIFF
--- a/8x2/vite.config.ts
+++ b/8x2/vite.config.ts
@@ -4,6 +4,7 @@ import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/okyeron.github.io/',
   plugins: [vue()],
   resolve: {
     alias: [{ find: '@', replacement: resolve(__dirname, './src') }],


### PR DESCRIPTION
Allegedly fixes issue with not resolving relative resources on load of `index.html`.