### PR TITLE
Find ports based on manufacturer and name substring

### DIFF
--- a/8x2/src/access/composables/hachiNi.ts
+++ b/8x2/src/access/composables/hachiNi.ts
@@ -2,6 +2,7 @@ import { computed, reactive, readonly, ref, watchEffect } from 'vue';
 import { Mappings, Bank, Info, Banks, MIDICallbacks, Mapping } from '@/access/types';
 import { useWebMidi } from './webMidi';
 
+const deviceManufacturer = 'denki-oto';
 const deviceName = 'hachi-ni';
 const manufacturerId = [125, 0, 0];
 const requestConfigMessage = [0xf0, ...manufacturerId, 0x1f, 0xf7];
@@ -111,7 +112,7 @@ export const useHachiNi = () => {
     },
   ];
 
-  const { access, output, connected } = useWebMidi(deviceName, callbacks);
+  const { access, output, connected } = useWebMidi(deviceManufacturer, deviceName, callbacks);
 
   // 8x2 specific concept of connecting. i.e. The input/output ports are connected,
   // and we are awaiting receipt of the initial config state for the active bank.

--- a/8x2/src/access/composables/webMidi.ts
+++ b/8x2/src/access/composables/webMidi.ts
@@ -69,12 +69,15 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
     };
   };
 
+  const debug = (...message: any[]) => {
+    console.debug('[Web MIDI]:', ...message);
+  };
+
   watch(
     [access, connected, input, inputDeviceState, output, outputDeviceState],
     () => {
-      console.debug('[Web MIDI]: State History Snapshot -----------------------');
-
-      console.debug(
+      debug(
+        'State History Snapshot',
         JSON.stringify(
           {
             access: access.value,
@@ -88,8 +91,6 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
           2
         )
       );
-
-      console.debug('----------------------------------------------------------');
     },
     { immediate: true }
   );
@@ -102,7 +103,7 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
   navigator.permissions
     .query(midiPermission)
     .then((result) => {
-      console.debug(`[Web MIDI]: MIDI + Sysex permissions query result: ${result.state}`);
+      debug(`MIDI + Sysex permissions query result: ${result.state}`);
 
       if (result.state === 'prompt') {
         access.value = 'requesting';
@@ -113,17 +114,17 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
     .then(() => {
       navigator.requestMIDIAccess({ sysex: true }).then(
         (midiAccess) => {
-          console.debug('[Web MIDI]: MIDI access request: granted');
+          debug('MIDI access request: granted');
 
           midiAccess.addEventListener('statechange', stateChangeHandler);
 
-          console.debug(
-            '[Web MIDI]: Available MIDI Input ports:',
+          debug(
+            'Available MIDI Input ports:',
             JSON.stringify([...midiAccess.inputs.values()].map(extractPortProperties), null, 2)
           );
 
-          console.debug(
-            '[Web MIDI]: Available MIDI Output ports:',
+          debug(
+            'Available MIDI Output ports:',
             JSON.stringify([...midiAccess.outputs.values()].map(extractPortProperties), null, 2)
           );
 
@@ -133,7 +134,7 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
           access.value = 'enabled';
         },
         () => {
-          console.debug('[Web MIDI]: MIDI access request: denied');
+          debug('MIDI access request: denied');
 
           access.value = 'disabled';
         }
@@ -143,7 +144,7 @@ export const useWebMidi = (deviceName: string, callbacks: MIDICallbacks) => {
       // Likely caused by 'midi' not being in the PermissionName enumeration
       // or requestMIDIAccess not being a property of navigator:
       // i.e. browser doesn't support web MIDI.
-      console.debug(`[Web MIDI]: MIDI (permissions query/access request) error: ${e.message}`);
+      debug(`MIDI (permissions query/access request) error: ${e.message}`);
 
       access.value = 'disabled';
     });

--- a/OMX-27/webconfig/index.html
+++ b/OMX-27/webconfig/index.html
@@ -211,7 +211,7 @@
 		function showgrid(){
 			const main = document.getElementById("main");
 			var labels = ["Mode", "Playing Pattern", "Midi Channel"];
-			var modelist = ["MIDI", "S1", "S2", "OM"];
+			var modelist = ["MIDI", "CH", "S1", "S2", "GR", "EL", "OM"];
 
 			var t = document.createElement("dl");
 			t.setAttribute("class", "grid");


### PR DESCRIPTION
A Linux user was unable to use the configurator as the hachi-ni ports were never found.
 
The user's OS appended the suffix `MIDI <number>` to the device name. Since we were
  originally matching on the entire name, `"hachi-ni" !== "hachi-ni MIDI 1"`. With this
  change, we now fully match the manufacturer name `denki-oto` and then substring
  match `hachi-ni` against the device name.