### PR TITLE
Don't use manufacturer name when finding MIDI ports

### DIFF
--- a/8x2/src/access/composables/webMidi.ts
+++ b/8x2/src/access/composables/webMidi.ts
@@ -22,8 +22,8 @@ export const useWebMidi = (deviceManufacturer: string, deviceName: string, callb
     );
   });
 
-  const validPort = (port: WebMidi.MIDIPort) => {
-    return port.manufacturer === deviceManufacturer && port.name?.includes(deviceName);
+  const validPort = (port: WebMidi.MIDIPort): boolean => {
+    return port.name?.includes(deviceName) ?? false;
   };
 
   const stateChangeHandler = (e: WebMidi.MIDIConnectionEvent) => {


### PR DESCRIPTION
🤷‍♀️ Windows seemingly isn't exposing the manufacturer name so we shouldn't use it.