### PR TITLE
fix: specify web-editor base path for production deploy

### DIFF
--- a/web-editor/vite.config.ts
+++ b/web-editor/vite.config.ts
@@ -10,6 +10,7 @@ import { analyzer } from 'vite-bundle-analyzer'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/web-editor/',
   build: {
     rollupOptions: {
       plugins: [


### PR DESCRIPTION
Forgot to specify where the assets for the `web-editor` path are located. The page was incorrectly trying to find them at the root `/` path.